### PR TITLE
sets actfw_raspberrypi.__version__

### DIFF
--- a/actfw_raspberrypi/__init__.py
+++ b/actfw_raspberrypi/__init__.py
@@ -1,1 +1,5 @@
 from .display import Display
+
+from actfw_raspberrypi import _version
+
+__version__ = _version.__version__

--- a/actfw_raspberrypi/__init__.py
+++ b/actfw_raspberrypi/__init__.py
@@ -1,5 +1,2 @@
 from .display import Display
-
-from actfw_raspberrypi import _version
-
-__version__ = _version.__version__
+from ._version import __version__


### PR DESCRIPTION
Like actfw-core: https://github.com/Idein/actfw-core/blob/master/actfw_core/__init__.py#L9-L11

CI has failed due to lack of `__version__`: https://app.circleci.com/pipelines/github/Idein/actfw-raspberrypi/11/workflows/8b47f0af-0632-4353-a146-1922d2f689da/jobs/29