### PR TITLE
Fix drm backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.0 (2022-XX-XX)
+
+- Add DRM backend for Display
+
 ## 2.1.0a0 (2022-03-14)
 
 - Relax `actfw-core` version constraint: `=2.0.0` -> `^2.0.0`

--- a/actfw_raspberrypi/vc4/drm/drm.py
+++ b/actfw_raspberrypi/vc4/drm/drm.py
@@ -690,7 +690,7 @@ class Plane(object):
 
 class Device(object):
     def __init__(self):
-        self.fd = _drm.open(b"vc4", b"")
+        self.fd = _drm.open(b"vc4", None)
         if self.fd < 0:
             raise RuntimeError("fail to open drm device")
         if not _drm.support_dumb_buffer(self.fd):


### PR DESCRIPTION
## Check list

- [x] I wrote [CHANGELOG.md](./CHANGELOG.md) if the pull request adds/modifies features.

## Summary
After `drmOpen("v3d", NULL)`,

- `drmOpen("vc4", "")` opens v3d device
- `drmOpen("vc4", NULL)` opens vc4 device

in pi4.

We must open vc4 device to use display.